### PR TITLE
Migrate to Github Actions HTTP client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@actions/exec": "^1.1.1"
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.1.1"
       },
       "devDependencies": {
         "standard": "^17.1.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@actions/exec": "^1.1.1"
+    "@actions/exec": "^1.1.1",
+    "@actions/http-client": "^2.1.1"
   }
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,9 +1,11 @@
 import exec from '@actions/exec'
 import * as core from '@actions/core'
+import { HttpClient } from '@actions/http-client'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
-import https from 'node:https'
 import { join } from 'node:path'
+
+const httpAgent = new HttpClient('node-dist-health')
 
 export async function getAllResults () {
   const resultsFolder = join(process.cwd(), 'results')
@@ -83,19 +85,7 @@ export function overwriteReleaseUrls (urls) {
 }
 
 function downloadFile (url) {
-  return new Promise((resolve, reject) => {
-    https.get(url, (resp) => {
-      let data = ''
-
-      resp.on('data', (chunk) => {
-        data += chunk
-      })
-
-      resp.on('end', () => {
-        resolve(data)
-      })
-    }).on('error', reject)
-  })
+  return httpAgent.get(url).then(res => res.readBody())
 }
 
 export async function downloadReleases () {


### PR DESCRIPTION
### Main Changes

- Added dependency `@actions/http-client@2.1.1`
- Refactor to use http GH Actions HTTP client.

### Context

Related to #4

### Changelog

- a0a1994 chore: added dependency @actions/http-client@2.1.1 by @UlisesGascon
- 1de1b5d chore: refactor to use http github actions agent by @UlisesGascon